### PR TITLE
secure chat access

### DIFF
--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -9,6 +9,7 @@ export default async function ChatPage(props: { params: Promise<{ id: string }> 
   const { id } = await props.params;
   // Try to load existing chat, or start with empty messages
   let initialMessages: Message[] = [];
+  let notFound = false;
 
   const session = await auth.api.getSession({
     headers: await headers(),
@@ -20,10 +21,15 @@ export default async function ChatPage(props: { params: Promise<{ id: string }> 
   }
 
   try {
-    initialMessages = await loadChat(id);
+    initialMessages = await loadChat(session.user.id, id);
   } catch (error) {
+    notFound = true;
     // Chat doesn't exist yet, start fresh
     console.log(`Error loading chat ${id}:`, error);
+  }
+
+  if(notFound){
+    redirect('/')
   }
 
   return <Chat id={id} initialMessages={initialMessages} />;

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -1,6 +1,8 @@
-import { getAllChats } from "@/tools/chat-services";
+import { getAllChats, getChatsByUserId } from "@/tools/chat-services";
 import Link from "next/link";
 import { Button } from "./ui/button";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
 
 type ChatRowProps = {
   isLast: boolean;
@@ -27,7 +29,15 @@ const ChatRow = ({ isLast, id, date }: ChatRowProps) => {
 };
 
 export default async function ChatList() {
-  const chats = await getAllChats();
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  })
+
+  if(!session?.user) {
+    return <div className="text-center py-8">Please log in to see your chats.</div>;
+  }
+
+  const chats = await getChatsByUserId(session.user.id);
 
   return (
     <>

--- a/src/tools/chat-services.ts
+++ b/src/tools/chat-services.ts
@@ -2,10 +2,14 @@
 import type { Message } from 'ai';
 import { db } from '@/server/db'
 import { chats } from '@/server/db/schema';
-//import { eq } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 
 export async function getAllChats() {
     const chatList = await db.select().from(chats).orderBy(chats.createdAt)
-    console.log(chatList, "#### ALL CHATS FROM DB")
     return chatList
+}
+
+export async function getChatsByUserId(userId:string) {
+    const userChatList = await db.select().from(chats).where(eq(chats.userId, userId)).orderBy(chats.createdAt)
+    return  userChatList;
 }

--- a/src/tools/chat-store.ts
+++ b/src/tools/chat-store.ts
@@ -2,7 +2,7 @@ import { generateId } from 'ai';
 import type { Message } from 'ai';
 import { db } from '@/server/db'
 import { chats } from '@/server/db/schema';
-import { eq } from 'drizzle-orm'
+import { eq, and } from 'drizzle-orm'
 
 export async function createChat(userId: string): Promise<string> {
     const id = generateId();
@@ -16,8 +16,12 @@ export async function createChat(userId: string): Promise<string> {
     return id;
   }
 
-export async function loadChat(id: string): Promise<Message []> {
-    const chat = await db.select().from(chats).where(eq(chats.id, id)).limit(1)
+export async function loadChat(userId: string, id: string): Promise<Message []> {
+  /*
+    SELECT FROM chats 
+    select from table chats, where (chats.userid = the passes in userID) and (the passed in chat.id = chats.id)
+  */
+  const chat = await db.select().from(chats).where(and(eq(chats.userId, userId), eq(chats.id, id))).limit(1)
 
     if(!chat.length) {
         throw new Error(`Chat ${id} not found`);


### PR DESCRIPTION
secure chat access, only fetch and display chats that belong to the logged in user

-added logic in the db query where the `userID` from the `session` AND the `chatID` have to match in order to retrieve chat data
- added logic in `chat/id` page, for chants not being return
- return only `chats` in `chatList`  that belong to logged in user
- added `getChatByUserId` function for DB